### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/JsonPlaceHolder_API.yml
+++ b/.github/workflows/JsonPlaceHolder_API.yml
@@ -1,4 +1,6 @@
 name: JsonPlaceHolder API Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/3](https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/3)

To fix this problem, explicitly set the `permissions` key in the workflow to restrict the GITHUB_TOKEN's access to the least required scopes. The minimal needed for the current workflow is `contents: read`, which allows the workflow to clone the repo but not write to it. This `permissions` block should be added at the root level of the workflow file, before the `jobs:` section. This ensures all jobs default to this minimal permission set unless locally overridden.

No imports or special methods are necessary, as this is a YAML configuration change. Simply add the recommended permissions block immediately after the `name` field at the start of the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
