### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/GoRest_API.yml
+++ b/.github/workflows/GoRest_API.yml
@@ -1,4 +1,6 @@
 name: GoRest API Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/1](https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/1)

To fix this issue, add a `permissions` key with the minimal required permissions at the root of the workflow (`.github/workflows/GoRest_API.yml`). Since reviewing the workflow shows that no step evidently requires write access (checkout, setup, install, test, and upload artifact), the minimal permission `contents: read` is appropriate. You should add this key directly below the `name` line, before `on:` in the workflow file to apply to all jobs unless a job-level override is added in future. No change to functionality will result, and no imports or extra methods are needed—just an edit to the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
