### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Booking_API.yml
+++ b/.github/workflows/Booking_API.yml
@@ -1,4 +1,6 @@
 name: Booking API Tests
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/2](https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/2)

The fix involves adding a `permissions` block to the workflow, ideally at the top level. This sets explicit permissions for all jobs in the workflow. According to GitHub guidance and the workflow structure, the minimal required permission is likely `contents: read`. If other permissions are needed (for uploading artifacts, etc.), they should be added. For this workflow, set `permissions: contents: read` just beneath the workflow `name:` and before the `on:` section. No functional change occurs; instead, this explicitly communicates the low privilege level of the workflow, reducing potential risk.

Recommended edit:  
- File to edit: `.github/workflows/Booking_API.yml`
- Insert block:  
  - Below `name: Booking API Tests` and above `on:`, add:
    ```yaml
    permissions:
      contents: read
    ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
