### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Swagger_PetStore_API.yml
+++ b/.github/workflows/Swagger_PetStore_API.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   Pet_Store_API_Tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/4](https://github.com/SatyamAutoDeveloper/pytest-python-api-automation/security/code-scanning/4)

The problem should be fixed by adding a `permissions` block to the job definition (or at the workflow root if desired), specifying the least privilege required for the steps in this workflow. In this case, only `contents: read` is necessary, as the job checks out code and uploads artifacts, but does not need to write to the repository, create issues, or modify pull requests. Add the following block:
```yaml
permissions:
  contents: read
```
immediately before `runs-on: ubuntu-latest` under the job definition (`Pet_Store_API_Tests`). No other changes are needed for functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
